### PR TITLE
Combine cats

### DIFF
--- a/catalogbuilder/scripts/combine_cats.py
+++ b/catalogbuilder/scripts/combine_cats.py
@@ -61,7 +61,6 @@ def combine_cats(inputfiles,output_path):
 
     df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs], ignore_index = True)
     #df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs])
-    df_concat = df_concat.drop(['Unnamed: 0'],axis=1)
     df_concat.to_csv(combined_csv, index=False)
 
     #Write out a catalog specification 

--- a/catalogbuilder/scripts/combine_cats.py
+++ b/catalogbuilder/scripts/combine_cats.py
@@ -1,69 +1,85 @@
+#!/usr/bin/env python
+
 import pandas as pd
 import json
 from jsondiff import diff
 import pathlib
 import sys 
-import os
-#Get the catalog files to be combined. 
+import os, click
 
-#USER INPUT BEGINS 
+test = False
 
-#Pass the json catalog spec AND the combined_json which is the output path
+if(test == True):
+  json1 = "/home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json"
+  json2 = "/home/a1r/github/noaa-gfdl/catalogs/ESM4.5v01_om5b04_piC.json"
+  combined_json = "/home/a1r/github/noaa-gfdl/catalogs/combined_CM4.5v01_om5b06_piC_noBLING_and_ESM4.5v01_om5b04_piC.json"
 
-json1 = "/home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json" 
-json2 = "/home/a1r/github/noaa-gfdl/catalogs/ESM4.5v01_om5b04_piC.json"
-combined_json = "/home/a1r/github/noaa-gfdl/catalogs/combined_CM4.5v01_om5b06_piC_noBLING_and_ESM4.5v01_om5b04_piC.json"
-
-#USER INPUT ENDS
+@click.command()
+@click.option('-i','--inputfiles',required=True,multiple=True,help='Pass json catalog files to-be-combined, space separated')
+@click.option('-o','--output_path',required=True,nargs=1,help='Specify the output json path')
 
 #Assume csv is in the same path and deduce the filename
+def combine_cats(inputfiles,output_path):
+    """This script combines two json catalogs. It takes the path to input catalogs and the output catalog names as input. \nThe options may be passed with this as the template: \n combine_catalogs.py -i jsoncatalog -i jsoncatalog2 -o outputjson \n\n Example usage: combine_cats.py -i /home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json -i /home/a1r/github/noaa-gfdl/catalogs/ESM4.5v01_om5b04_piC.json -o combinedcat.json """
+    try:
+       json1 = inputfiles[0]
+    except:
+       sys.exit("cannot parse inputfiles")
+    try:
+       json2 = inputfiles[1]
+    except:
+       sys.exit("cannot parse inputfiles2")
+    try:
+       combined_json = output_path
+    except:
+       sys.exit("cannot parse output_path")
+    p1 = pathlib.PurePath(json1)
+    csv1 =  p1.with_suffix('.csv')
+    print(csv1)
+    p2 = pathlib.Path(json2)
+    csv2 = p2.with_suffix('.csv')
+    print(csv2)
 
-p1 = pathlib.PurePath(json1)
-csv1 =  p1.with_suffix('.csv')
-print(csv1)
+    cat_csvs = [csv1,csv2] #TODO check for valid paths, pass it with cmd line if necessary 
 
-p2 = pathlib.Path(json2)
-csv2 = p2.with_suffix('.csv')
-print(csv2)
+    #####Check if the schema is the same
+    with open(json1) as f1, open(json2) as f2:
+        json_obj1 = json.load(f1)
+        json_obj2 = json.load(f2) 
+    differ = diff(json_obj1, json_obj2) 
+    print("INFO: Schema differs")
+    print(differ)
+    if len(differ.keys()) == 1:
+      if "catalog_file" in differ.keys():
+          print("We can combine since the catalog_file is the only difference")
+    else:
+      print("Schema likely varies significantly, cannot combine")
+      sys.exit()
+    #### If the headers are the same, append the data frames together and create the combined csv 
+    p3 = pathlib.Path(combined_json)
+    combined_csv = p3.with_suffix('.csv')
 
+    df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs], ignore_index = True)
+    #df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs])
+    df_concat = df_concat.drop(['Unnamed: 0'],axis=1)
+    df_concat.to_csv(combined_csv, index=False)
 
-cat_csvs = [csv1,csv2] #TODO check for valid paths, pass it with cmd line if necessary 
-
-#####Check if the schema is the same
-with open(json1) as f1, open(json2) as f2:
-    json_obj1 = json.load(f1)
-    json_obj2 = json.load(f2) 
-differ = diff(json_obj1, json_obj2) 
-print("INFO: Schema differs")
-print(differ)
-if len(differ.keys()) == 1:
-  if "catalog_file" in differ.keys():
-      print("We can combine since the catalog_file is the only difference")
-else:
-  print("Schema likely varies significantly, cannot combine")
-  sys.exit()
-#### If the headers are the same, append the data frames together and create the combined csv 
-p3 = pathlib.Path(combined_json)
-combined_csv = p3.with_suffix('.csv')
-
-df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs], ignore_index = True)
-#df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs])
-df_concat = df_concat.drop(['Unnamed: 0'],axis=1)
-df_concat.to_csv(combined_csv, index=False)
-
-#Write out a catalog specification 
-f = open(json1)
-catspec = json.load(f)
-for catalog_file in catspec['catalog_file']:
-   catspec['catalog_file'] = os.fspath(combined_csv)
-#Write out the combined json 
+    #Write out a catalog specification 
+    f = open(json1)
+    catspec = json.load(f)
+    for catalog_file in catspec['catalog_file']:
+       catspec['catalog_file'] = os.fspath(combined_csv)
+    #Write out the combined json 
  
-json_data = json.dumps(catspec,indent=4)
-with open(combined_json,'w') as outfile:
-  outfile.write(json_data)
+    json_data = json.dumps(catspec,indent=4)
+    with open(combined_json,'w') as outfile:
+      outfile.write(json_data)
+    #Print pointers 
+    print("Combined catalog specification- ", combined_json)
+    print("Combined csv/catalog- ", combined_csv)
 
+def combine_cats_cli(**kwargs):
+    return combine_cats(**kwargs)
 
-#Print pointers 
-
-print("Combined catalog specification- ", combined_json)
-print("Combined csv/catalog- ", combined_csv)
+if __name__ == '__main__':
+    combine_cats_cli()

--- a/catalogbuilder/scripts/combine_cats.py
+++ b/catalogbuilder/scripts/combine_cats.py
@@ -1,12 +1,20 @@
 import pandas as pd
 import json
+from jsondiff import diff
 import pathlib
 import sys 
 import os
-#Set the csv files to be combined. The csv files here are the catalog files. 
+#Get the catalog files to be combined. 
 
-#csv1 = "/home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.csv"
+#USER INPUT BEGINS 
+
+#Pass the json catalog spec AND the combined_json which is the output path
+
 json1 = "/home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json" 
+json2 = "/home/a1r/github/noaa-gfdl/catalogs/ESM4.5v01_om5b04_piC.json"
+combined_json = "/home/a1r/github/noaa-gfdl/catalogs/combined_CM4.5v01_om5b06_piC_noBLING_and_ESM4.5v01_om5b04_piC.json"
+
+#USER INPUT ENDS
 
 #Assume csv is in the same path and deduce the filename
 
@@ -14,7 +22,6 @@ p1 = pathlib.PurePath(json1)
 csv1 =  p1.with_suffix('.csv')
 print(csv1)
 
-json2 = "/home/a1r/github/noaa-gfdl/catalogs/ESM4.5v01_om5b04_piC.json"
 p2 = pathlib.Path(json2)
 csv2 = p2.with_suffix('.csv')
 print(csv2)
@@ -22,11 +29,20 @@ print(csv2)
 
 cat_csvs = [csv1,csv2] #TODO check for valid paths, pass it with cmd line if necessary 
 
-#####Check if the header of the csvs are the same #######
-
-
+#####Check if the schema is the same
+with open(json1) as f1, open(json2) as f2:
+    json_obj1 = json.load(f1)
+    json_obj2 = json.load(f2) 
+differ = diff(json_obj1, json_obj2) 
+print("INFO: Schema differs")
+print(differ)
+if len(differ.keys()) == 1:
+  if "catalog_file" in differ.keys():
+      print("We can combine since the catalog_file is the only difference")
+else:
+  print("Schema likely varies significantly, cannot combine")
+  sys.exit()
 #### If the headers are the same, append the data frames together and create the combined csv 
-combined_json = "/home/a1r/github/noaa-gfdl/catalogs/combined_CM4.5v01_om5b06_piC_noBLING_and_ESM4.5v01_om5b04_piC.json"
 p3 = pathlib.Path(combined_json)
 combined_csv = p3.with_suffix('.csv')
 

--- a/catalogbuilder/scripts/combine_cats.py
+++ b/catalogbuilder/scripts/combine_cats.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import json
+import pathlib
+import sys 
+import os
+#Set the csv files to be combined. The csv files here are the catalog files. 
+
+#csv1 = "/home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.csv"
+json1 = "/home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json" 
+
+#Assume csv is in the same path and deduce the filename
+
+p1 = pathlib.PurePath(json1)
+csv1 =  p1.with_suffix('.csv')
+print(csv1)
+
+json2 = "/home/a1r/github/noaa-gfdl/catalogs/ESM4.5v01_om5b04_piC.json"
+p2 = pathlib.Path(json2)
+csv2 = p2.with_suffix('.csv')
+print(csv2)
+
+
+cat_csvs = [csv1,csv2] #TODO check for valid paths, pass it with cmd line if necessary 
+
+#####Check if the header of the csvs are the same #######
+
+
+#### If the headers are the same, append the data frames together and create the combined csv 
+combined_json = "/home/a1r/github/noaa-gfdl/catalogs/combined_CM4.5v01_om5b06_piC_noBLING_and_ESM4.5v01_om5b04_piC.json"
+p3 = pathlib.Path(combined_json)
+combined_csv = p3.with_suffix('.csv')
+
+df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs], ignore_index = True)
+#df_concat = pd.concat([pd.read_csv(f) for f in cat_csvs])
+df_concat = df_concat.drop(['Unnamed: 0'],axis=1)
+df_concat.to_csv(combined_csv, index=False)
+
+#Write out a catalog specification 
+f = open(json1)
+catspec = json.load(f)
+for catalog_file in catspec['catalog_file']:
+   catspec['catalog_file'] = os.fspath(combined_csv)
+#Write out the combined json 
+ 
+json_data = json.dumps(catspec,indent=4)
+with open(combined_json,'w') as outfile:
+  outfile.write(json_data)
+
+
+#Print pointers 
+
+print("Combined catalog specification- ", combined_json)
+print("Combined csv/catalog- ", combined_csv)


### PR DESCRIPTION
Initial attempt to address #56.
Encourage user contributions to make the tool robust and more usable. 

Here's the current user interface

```
combine_cats.py --help
Usage: combine_cats.py [OPTIONS]

  This script combines two json catalogs. It takes the path to input catalogs
  and the output catalog names as input. The options may be passed with this
  as the template:  combine_catalogs.py -i jsoncatalog -i jsoncatalog2 -o
  outputjson

  Example usage: combine_cats.py -i /home/a1r/github/noaa-
  gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json -i /home/a1r/github/noaa-
  gfdl/catalogs/ESM4.5v01_om5b04_piC.json -o combinedcat.json

Options:
  -i, --inputfiles TEXT   Pass json catalog files to-be-combined, space
                          separated  [required]
  -o, --output_path TEXT  Specify the output json path  [required]
  --help                  Show this message and exit.

```

You may test it with this:

```
combine_cats.py -i /home/a1r/github/noaa-
  gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json -i /home/a1r/github/noaa-
  gfdl/catalogs/ESM4.5v01_om5b04_piC.json -o combinedcat.json
```

I have an example of a combined catalog here: 
/home/a1r/github/noaa-gfdl/catalogs/CM4_and_ESM45_combined.json


The script ensures the diff of the two json catalogs passed is nearly zero (except for catalog_file path) and then uses pandas to concatenate. The header files are used from one of the input files. 