### PR TITLE
update link for gfdl-cmor tables to main MDTF branch in getinfo.py

### DIFF
--- a/catalogbuilder/intakebuilder/getinfo.py
+++ b/catalogbuilder/intakebuilder/getinfo.py
@@ -249,8 +249,8 @@ def getStandardName(list_variable_id,list_realm):
   unique_cf = "na"
   dictCF = {}
   try:
-      url = "https://raw.githubusercontent.com/NOAA-GFDL/MDTF-diagnostics/b5e7916c203f3ba0b53e9e40fb8dc78ecc2cf5c3/data/gfdl-cmor-tables/gfdl_to_cmip5_vars.csv"
-      url2 = "https://raw.githubusercontent.com/NOAA-GFDL/MDTF-diagnostics/b5e7916c203f3ba0b53e9e40fb8dc78ecc2cf5c3/data/gfdl-cmor-tables/gfdl_to_cmip6_vars.csv"
+      url = "https://raw.githubusercontent.com/NOAA-GFDL/MDTF-diagnostics/refs/heads/main/data/gfdl-cmor-tables/gfdl_to_cmip5_vars.csv"
+      url2 = "https://raw.githubusercontent.com/NOAA-GFDL/MDTF-diagnostics/refs/heads/main/data/gfdl-cmor-tables/gfdl_to_cmip6_vars.csv"
       df1 = pd.read_csv(url, sep=",", header=0,index_col=False)
       df2 = pd.read_csv(url2, sep=",", header=0,index_col=False)
       #TODO Add try catch except for concat operation if concat fails for some reason 


### PR DESCRIPTION
The old links used would direct to an older commit of the MDTF repo. This makes changes to the csv files unseen by the CatalogBuilder. The new links direct to what is seen on the main branch.

This is related to issue #77.