### PR TITLE
ERA5 catalogs -- filename accommodation

### DIFF
--- a/catalogbuilder/intakebuilder/gfdlcrawler.py
+++ b/catalogbuilder/intakebuilder/gfdlcrawler.py
@@ -79,7 +79,7 @@ def crawlLocal(projectdir, dictFilter,dictFilterIgnore,logger,configyaml,slow):
                    continue
                #if our filename expectations are not met compared to the output_file_path_template in config, skip the loop. TODO revisit for statics
                if ("static" not in filename):
-                 splitchar = "_" if "/uda" in filename else "."
+                 splitchar = "_" if "/uda" in filepath else "."
                  if ((len(filename.split(splitchar))-1) != len(set_ftemplate)):
                    logger.debug("Skipping "+filename)
                    continue 

--- a/catalogbuilder/intakebuilder/gfdlcrawler.py
+++ b/catalogbuilder/intakebuilder/gfdlcrawler.py
@@ -79,7 +79,8 @@ def crawlLocal(projectdir, dictFilter,dictFilterIgnore,logger,configyaml,slow):
                    continue
                #if our filename expectations are not met compared to the output_file_path_template in config, skip the loop. TODO revisit for statics
                if ("static" not in filename):
-                 if ((len(filename.split('.'))-1) != len(set_ftemplate)):
+                 splitchar = "_" if "/uda" in filename else "."
+                 if ((len(filename.split(splitchar))-1) != len(set_ftemplate)):
                    logger.debug("Skipping "+filename)
                    continue 
                logger.debug(dirpath+"/"+filename)


### PR DESCRIPTION
Adjusts crawler script to scan for files not containing a "." character within the name if the file comes from the UDA.