### PR TITLE
Unpin intake-esm dependency to a specific version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,5 @@ dependencies:
   - xarray
   - pandas
   - jsondiff
-  - intake-esm=2023.7.7
+  - intake-esm
   - boto3

--- a/meta.yaml
+++ b/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - xarray
     - pandas
     - jsondiff
-    - conda-forge::intake-esm=2023.7.7
+    - conda-forge::intake-esm
     - boto3
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'xarray',
         'pandas',
         'jsondiff',
-        'intake-esm==2023.7.7',
+        'intake-esm',
         'boto3'
     ]
 )


### PR DESCRIPTION
Previously, a specific intake-esm version was desired (2023.7.7), but likely it's not needed any longer, and may be causing other problems.