### PR TITLE
Create documentation for combining catalogs + bump to 2026.01.01

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -22,8 +22,9 @@ jobs:
 
       - name: Validate version bump selection
         id: validate
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_BODY="${{ github.event.pull_request.body }}"
           PR_BODY=$(echo "$PR_BODY" | tr -d '\r')
           BUMP_RESULT=$(python .github/scripts/determine_bump.py "$PR_BODY")
           STATUS=$?

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -24,6 +24,7 @@ jobs:
         id: validate
         run: |
           PR_BODY="${{ github.event.pull_request.body }}"
+          PR_BODY=$(echo "$PR_BODY" | tr -d '\r')
           BUMP_RESULT=$(python .github/scripts/determine_bump.py "$PR_BODY")
           STATUS=$?
           if [ "$STATUS" -ne 0 ] || [ "$BUMP_RESULT" = "none" ]; then

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -28,11 +28,11 @@ jobs:
           PR_BODY=$(echo "$PR_BODY" | tr -d '\r')
           BUMP_RESULT=$(python .github/scripts/determine_bump.py "$PR_BODY")
           STATUS=$?
-          if [ "$STATUS" -ne 0 ] || [ "$BUMP_RESULT" = "none" ]; then
+          if [ "$STATUS" -ne 0 ]; then
             echo "Version bump checkbox validation failed"
             exit 1
           else
-            echo "Version bump checkbox is properly selected"
+            echo "Version bump checkbox is properly selected: $BUMP_RESULT"
             exit 0
           fi
 

--- a/doc/combination.rst
+++ b/doc/combination.rst
@@ -1,0 +1,28 @@
+Combining Catalogs
+==================
+
+Users are able to merge two catalogs into a single catalog specification by using the catalog combing tool. The tool can be accessed by calling the ``combine_cats.py`` script located in the catalogbuilder/scripts directory.
+
+
+It is intended for users who seek to:
+
+* Concatenate two CSVs into one combined CSV.
+* Produce a new JSON catalog specification that points to the combined CSV.
+
+Using the catalog combining tool
+--------------------------------
+
+The catalog combining tool can be found in catalogbuilder/scripts/combine_cats.py
+
+It can be called like this:
+
+    combine_catalogs.py -i jsoncatalog -i jsoncatalog2 -o outputjson
+
+Example usage: combine_cats.py -i /home/a1r/github/noaa-gfdl/catalogs/CM4.5v01_om5b06_piC_noBLING.json -i /home/a1r/github/noaa-gfdl/catalogs/ESM4.5v01_om5b04_piC.json -o combinedcat.json
+
+Options:
+  -i, --inputfiles TEXT   Pass json catalog files to-be-combined, space
+                          separated  [required]
+  -o, --output_path TEXT  Specify the output json path  [required]
+  --help                  Show this message and exit.
+

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: catalogbuilder
-  version: 2025.01.01
+  version: 2026.01.01
 
 source:
   path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "catalogbuilder"
-version = "2026.0.0"
+version = "2026.01.01"
 description = "intake-esm Catalog Generation Utilities"
 readme = "README.md"
 license = "CC-BY-NC-SA-4.0"
@@ -37,14 +37,14 @@ catalogbuilder = [
 ]
 
 [tool.bumpversion]
-current_version = "2026.0.0"
+current_version = "2026.01.01"
 commit = true
 commit_message = "chore: bump version {current_version} → {new_version}"
 tag = true
 tag_name = "{new_version}"
 allow_dirty = false
 parse = "(?P<year>\\d+)\\.(?P<major>\\d+)\\.(?P<minor>\\d+)"
-serialize = ["{year}.{major}.{minor}"]
+serialize = ["{year}.{major:02}.{minor:02}"]
 
 [tool.bumpversion.parts.year]
 calver_format = "{YYYY}"


### PR DESCRIPTION
## Description
Creates new documentation on combining catalogs. This PR also corrects the version number to 2026.01.01.

## Version Bump (Required - select one)
- [x] **No version bump** - This is a documentation update or refactoring (no version change)
- [ ] **Minor version** - This is a bug fix or patch (increments year.0.x)
- [ ] **Major version** - This is a new feature (increments year.x.0)

*Note: The year is automatically managed by calendar versioning and cannot be bumped here.*

## Checklist 
- [ ] I have tested these changes locally
- [ ] My code follows the style guidelines of this project
- [x] I have updated the documentation accordingly
- [ ] I have added/updated tests as necessary
